### PR TITLE
Fix hovering profession auto opening window

### DIFF
--- a/ls_Glass/init.lua
+++ b/ls_Glass/init.lua
@@ -560,7 +560,7 @@ function E:OnEnable()
 			if linkType == "battlepet" then
 				GameTooltip:SetOwner(chatFrame, "ANCHOR_CURSOR_RIGHT", 4, 2)
 				BattlePetToolTip_ShowLink(text)
-			else
+			elseif linkType ~= "trade" then
 				GameTooltip:SetOwner(chatFrame, "ANCHOR_CURSOR_RIGHT", 4, 2)
 
 				local isOK = pcall(GameTooltip.SetHyperlink, GameTooltip, link)


### PR DESCRIPTION
This adds a check for the "trade" linkType which is what the profession links fall under and only does the popup for non trade links.